### PR TITLE
Fix python3 compatibility for the clean_doc domain method

### DIFF
--- a/sphinx_idl/domain.py
+++ b/sphinx_idl/domain.py
@@ -286,7 +286,7 @@ class IDLDomain(Domain):
     }
 
     def clear_doc(self, docname):
-        for fullname, (fn, _) in self.data['objects'].items():
+        for fullname, (fn, _) in list(self.data['objects'].items()):
             if fn == docname:
                 del self.data['objects'][fullname]
 


### PR DESCRIPTION
`clean_doc` depends on modifying a dictionary while iterating over
its items, but `.items()` is an iterator in python3 (it is a list
in python2)
