### PR TITLE
Fully-qualify roles in autodoc summary tables

### DIFF
--- a/sphinx_idl/auto.py
+++ b/sphinx_idl/auto.py
@@ -99,9 +99,9 @@ class IDLAutoBase(Directive):
     def handle_idl_object_table(self, obj):
         """docstring for handle_idl_object_table"""
         if obj.kind == 'pro':
-            signature_line = ":pro:`{}`".format(obj.name)
+            signature_line = ":idl:pro:`{}`".format(obj.name)
         elif obj.kind == 'function':
-            signature_line = ":func:`{}`".format(obj.name)
+            signature_line = ":idl:func:`{}`".format(obj.name)
         try:
             summary_line = obj.docstring.strip().splitlines()[0]
         except IndexError:


### PR DESCRIPTION
Role references should use `:idl:func:` and `:idl:pro:` because
we can't assume that the primary domain is set to `idl` in `conf.py`
